### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/IlFeeWaiver/data/questions/IL_fee_waiver_body.yml
+++ b/docassemble/IlFeeWaiver/data/questions/IL_fee_waiver_body.yml
@@ -1541,9 +1541,9 @@ question: |
   Do you want to add your e-signature to your ${ form_name }?
 subquestion: |
   % if filing_basis != "filing_self":          
-  This program can put "**/s/ ${signer[0].name.full(middle="full")}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${signer[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % else:
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % endif
 
   If you do not add your **{e-signature}**, you must sign your paper form before you file it.
@@ -1609,9 +1609,9 @@ question: |
 signature: users[0].signature
 under: |
   % if filing_basis == "filing_self":
-    ${ users[0].name.full(middle="full") }
+    ${ users[0].name_full() }
   % else:
-    ${ signer[0].name.full(middle="full") }
+    ${ signer[0].name_full() }
   % endif
 ---
 id: court choice
@@ -1658,14 +1658,14 @@ review:
       **Plaintiffs / Petitioners**
 
       % for item in plaintiffs:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: defendants.revisit
     button: |
       **Defendants / Respondents**
 
       % for item in defendants:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: 
       - trial_court_index
@@ -2087,9 +2087,9 @@ review:
       ${ signature_choice.capitalize() }      
       % elif signature_choice == "add name":
       % if filing_basis == "filing_self":
-      ${ "Add /s/ " + users[0].name.full(middle="full") }
+      ${ "Add /s/ " + users[0].name_full() }
       % else:
-      ${ "Add /s/ " + signer[0].name.full(middle="full") }
+      ${ "Add /s/ " + signer[0].name_full() }
       % endif
       % elif signature_choice == "no signature":
       ${ "Leave blank and sign later" }
@@ -2144,7 +2144,7 @@ table: plaintiffs.table
 rows: plaintiffs
 columns:
   - name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2163,7 +2163,7 @@ table: defendants.table
 rows: defendants
 columns:
   - name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2182,7 +2182,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2191,7 +2191,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2437,20 +2437,20 @@ attachments:
       - "trial_court_county": ${ trial_court.address.county }
       - "plaintiff": |
           % if plaintiffs.number() > 1:
-          ${ plaintiffs[0].name.full(middle="full") }, et al.
+          ${ plaintiffs[0].name_full() }, et al.
           % else:
-          ${ plaintiffs[0].name.full(middle="full") }
+          ${ plaintiffs[0].name_full() }
           % endif
       - "defendant": |
           % if defendants.number() > 1:
-          ${ defendants[0].name.full(middle="full") }, et al.
+          ${ defendants[0].name_full() }, et al.
           % else:
-          ${ defendants[0].name.full(middle="full") }      
+          ${ defendants[0].name_full() }      
           % endif
       - "docket_number": ${ docket_number }
       - "docket_number__1": ${ docket_number }
       - "docket_number__2": ${ docket_number }
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
 
   - name: IL fee waiver supplement
     filename: winnebago_supplement
@@ -2464,9 +2464,9 @@ attachments:
       - "docket_number": ${ docket_number }
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "signer_phone_number": |
           % if filing_basis != "filing_self":
@@ -2485,9 +2485,9 @@ attachments:
       - "signer_signature_slash_s": |
           % if signature_choice == "add name":
           % if filing_basis != "filing_self":
-          ${ "/s/ " + signer[0].name.full(middle="full") }
+          ${ "/s/ " + signer[0].name_full() }
           % else:
-          ${ "/s/ " + users[0].name.full(middle="full") }
+          ${ "/s/ " + users[0].name_full() }
           % endif
           % endif
           
@@ -2504,9 +2504,9 @@ attachments:
           ${ in_re_label }
           % else:
           % if plaintiffs.number() > 1:
-          ${ plaintiffs[0].name.full(middle="full") }, et al.
+          ${ plaintiffs[0].name_full() }, et al.
           % else:
-          ${ plaintiffs[0].name.full(middle="full") }
+          ${ plaintiffs[0].name_full() }
           % endif
           % endif
       - "defendant": |
@@ -2514,9 +2514,9 @@ attachments:
           ${ "" }
           % else:
           % if defendants.number() > 1:
-          ${ defendants[0].name.full(middle="full") }, et al.
+          ${ defendants[0].name_full() }, et al.
           % else:
-          ${ defendants[0].name.full(middle="full") }      
+          ${ defendants[0].name_full() }      
           % endif
           % endif
       - "docket_number": ${ docket_number }
@@ -2525,20 +2525,20 @@ attachments:
       - "docket_number__3": ${ docket_number }
       - "filing_self_cb": ${ True if filing_basis == "filing_self" else ""}
       - "filing_obo_cb": ${ True if filing_basis != "filing_self" else ""}
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
       - "user_address_one_line": ${ users[0].address.on_one_line(bare=True) }
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "user_address_one_line__2": ${ users[0].address.on_one_line(bare=True) }
       - "signer_signature_no_slash": |
           % if filing_basis != "filing_self":          
-          ${ signer[0].name.full(middle="full") if e_signature else '' }
+          ${ signer[0].name_full() if e_signature else '' }
           % else:
-          ${ users[0].name.full(middle="full") if e_signature else ''  }
+          ${ users[0].name_full() if e_signature else ''  }
           % endif
       - "signer_email": |
           % if filing_basis != "filing_self":


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>